### PR TITLE
Fixed github dependabot alerts

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -16,6 +16,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "ssri": ">=5.2.2",
+    "hoek": ">=4.2.1",
+    "cryptiles": ">=4.1.2",
     "@types/bcrypt": "^3.0.0",
     "@types/body-parser": "^1.19.0",
     "@types/cors": "^2.8.8",


### PR DESCRIPTION
Added the following dependencies to server/package.json to suppress DependaBot warnings:
- ssri (>=5.2.2)
- hoek (>=4.2.1)
- cryptiles (>=4.1.2)